### PR TITLE
add GHA

### DIFF
--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -1,0 +1,33 @@
+name: Nix Flake actions
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  nix-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v24
+      - id: set-matrix
+        name: Generate Nix Matrix
+        run: |
+          set -Eeu
+          matrix="$(nix eval --json '.#githubActions.matrix')"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  nix-build:
+    needs: nix-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v24
+      - run: nix build -L ".#${{ matrix.attr }}"

--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -30,6 +30,15 @@ jobs:
       fail-fast: false # let it build all the targets
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
     steps:
+      # Make space for large NixOS closures
+      - name: Free disk space
+        run: |
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            "$AGENT_TOOLSDIRECTORY" \
+            || true
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v24
       - run: nix build -L ".#githubActions.checks.${{ matrix.attr }}"

--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -43,6 +43,6 @@ jobs:
       - uses: cachix/install-nix-action@v24
       - uses: cachix/cachix-action@v14
         with:
-          name: test-slowflake
+          name: slowflake
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build -L ".#githubActions.checks.${{ matrix.attr }}"

--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -43,6 +43,6 @@ jobs:
       - uses: cachix/install-nix-action@v24
       - uses: cachix/cachix-action@v14
         with:
-          name: slowflake
+          name: snowflake
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build -L ".#githubActions.checks.${{ matrix.attr }}"

--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -18,9 +18,10 @@ jobs:
       - id: set-matrix
         name: Generate Nix Matrix
         run: |
-          set -Eeu
+          set -euo pipefail
           matrix="$(nix eval --json '.#githubActions.matrix')"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "$matrix" | jq
 
   nix-build:
     needs: nix-matrix
@@ -30,4 +31,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v24
-      - run: nix build -L ".#${{ matrix.attr }}"
+      - run: nix build -L ".#githubActions.checks.${{ matrix.attr }}"

--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -27,6 +27,7 @@ jobs:
     needs: nix-matrix
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false # let it build all the targets
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -41,4 +41,8 @@ jobs:
             || true
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v24
+      - uses: cachix/cachix-action@v14
+        with:
+          name: test-slowflake
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build -L ".#githubActions.checks.${{ matrix.attr }}"

--- a/flake.lock
+++ b/flake.lock
@@ -455,6 +455,26 @@
         "type": "github"
       }
     },
+    "nix-github-actions_3": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703863825,
+        "narHash": "sha256-rXwqjtwiGKJheXB43ybM8NwWB8rO2dSRrEqes0S7F5Y=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "5163432afc817cf8bd1f031418d1869e4c9d5547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1711163522,
@@ -620,6 +640,7 @@
         "hardware": "hardware",
         "home-manager": "home-manager_2",
         "jovian-nixos": "jovian-nixos",
+        "nix-github-actions": "nix-github-actions_3",
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-pr-169155": "nixpkgs-pr-169155",
         "nixpkgs-pr-269415": "nixpkgs-pr-269415",

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,11 @@
         inherit system;
         config.allowUnfree = true;
       });
-      withPrefix = prefix: lib.mapAttrs' (name: value: { name = "${prefix}${name}"; inherit value; });
+      withPrefix = prefix: lib.mapAttrs' (name: value: {
+        # Also remove special characters
+        name = lib.replaceStrings ["." "@"] ["_" "_"] "${prefix}${name}";
+        inherit value;
+      });
     in
     {
       githubActions = nix-github-actions.lib.mkGithubMatrix {

--- a/flake.nix
+++ b/flake.nix
@@ -132,8 +132,10 @@
 
       # Run `nix flake check`
       checks = forEachSystem (pkgs:
-        # add all the packages to checks
-        (withPrefix "pkgs-" self.packages.${pkgs.system})
+        # add all the supported packages to checks
+        (withPrefix "pkgs-"
+          (lib.filterAttrs (_: x: lib.elem pkgs.system x.meta.platforms)
+            self.packages.${pkgs.system}))
         # add the NixOS configurations with the same system
         //
         (withPrefix "nixos-"

--- a/flake.nix
+++ b/flake.nix
@@ -17,9 +17,11 @@
     jovian-nixos.url = "github:Jovian-Experiments/Jovian-NixOS";
     chaotic.url = "github:chaotic-cx/nyx/nyxpkgs-unstable";
     nixpkgs-pr-299036.url = "github:Shawn8901/nixpkgs?ref=fix-extest-extraenv";
+    nix-github-actions.url = "github:nix-community/nix-github-actions";
+    nix-github-actions.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, disko, nixpkgs, nixpkgs-unstable, home-manager, chaotic, jovian-nixos, ... }@inputs:
+  outputs = { self, disko, nixpkgs, nixpkgs-unstable, home-manager, chaotic, jovian-nixos, nix-github-actions, ... }@inputs:
     let
       inherit (self) outputs;
       lib = nixpkgs.lib // home-manager.lib;
@@ -31,6 +33,7 @@
       });
     in
     {
+      githubActions = nix-github-actions.lib.mkGithubMatrix { inherit (self) checks; };
       packages = forEachSystem (pkgs: import ./pkgs { inherit pkgs; });
       devShells = forEachSystem (pkgs: import ./shell.nix { inherit pkgs; });
       overlays = import ./overlays { inherit inputs outputs; };

--- a/flake.nix
+++ b/flake.nix
@@ -132,6 +132,12 @@
           (lib.mapAttrs (_: x: x.config.system.build.toplevel)
             (lib.filterAttrs (_: x: x.pkgs.system == pkgs.system)
               self.nixosConfigurations)))
+        # add the Home Manager configurations with the same system
+        //
+        (withPrefix "home-"
+          (lib.mapAttrs (_: x: x.activation-script)
+            (lib.filterAttrs (_: x: x.pkgs.system == pkgs.system)
+              self.homeConfigurations)))
       );
 
     };

--- a/flake.nix
+++ b/flake.nix
@@ -125,6 +125,12 @@
       checks = forEachSystem (pkgs:
         # add all the packages to checks
         (withPrefix "pkgs-" self.packages.${pkgs.system})
+        # add the NixOS configurations with the same system
+        //
+        (withPrefix "nixos-"
+          (lib.mapAttrs (_: x: x.config.system.build.toplevel)
+            (lib.filterAttrs (_: x: x.pkgs.system == pkgs.system)
+              self.nixosConfigurations)))
       );
 
     };

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
       githubActions = nix-github-actions.lib.mkGithubMatrix {
         # aarch64-linux is not supported by GitHub
         checks = nixpkgs.lib.getAttrs [ "x86_64-linux" "x86_64-darwin" ] self.checks;
+        attrPrefix = "";
       };
       packages = forEachSystem (pkgs: import ./pkgs { inherit pkgs; });
       devShells = forEachSystem (pkgs: import ./shell.nix { inherit pkgs; });

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,10 @@
       withPrefix = prefix: lib.mapAttrs' (name: value: { name = "${prefix}${name}"; inherit value; });
     in
     {
-      githubActions = nix-github-actions.lib.mkGithubMatrix { inherit (self) checks; };
+      githubActions = nix-github-actions.lib.mkGithubMatrix {
+        # aarch64-linux is not supported by GitHub
+        checks = nixpkgs.lib.getAttrs [ "x86_64-linux" "x86_64-darwin" ] self.checks;
+      };
       packages = forEachSystem (pkgs: import ./pkgs { inherit pkgs; });
       devShells = forEachSystem (pkgs: import ./shell.nix { inherit pkgs; });
       overlays = import ./overlays { inherit inputs outputs; };

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
         inherit system;
         config.allowUnfree = true;
       });
+      withPrefix = prefix: lib.mapAttrs' (name: value: { name = "${prefix}${name}"; inherit value; });
     in
     {
       githubActions = nix-github-actions.lib.mkGithubMatrix { inherit (self) checks; };
@@ -119,5 +120,12 @@
           ];
         };
       };
+
+      # Run `nix flake check`
+      checks = forEachSystem (pkgs:
+        # add all the packages to checks
+        (withPrefix "pkgs-" self.packages.${pkgs.system})
+      );
+
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -98,13 +98,14 @@
             ./home-manager/hosts/e39.nwk3.rabbito.tech.nix
           ];
         };
-        "anthony@nicoles-mbp.nwk3.rabbito.tech" = lib.homeManagerConfiguration {
-          pkgs = pkgsFor.x86_64-darwin;
-          extraSpecialArgs = { inherit inputs outputs; };
-          modules = [
-            ./home-manager/hosts/nicoles-mbp.nwk3.rabbito.tech.nix
-          ];
-        };
+        # FIXME: depends on packages that don't build on that system
+        # "anthony@nicoles-mbp.nwk3.rabbito.tech" = lib.homeManagerConfiguration {
+        #   pkgs = pkgsFor.x86_64-darwin;
+        #   extraSpecialArgs = { inherit inputs outputs; };
+        #   modules = [
+        #     ./home-manager/hosts/nicoles-mbp.nwk3.rabbito.tech.nix
+        #   ];
+        # };
         "steam@octo.nwk3.rabbito.tech" = lib.homeManagerConfiguration {
           pkgs = pkgsFor.x86_64-linux;
           extraSpecialArgs = { inherit inputs outputs; };

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
     let
       inherit (self) outputs;
       lib = nixpkgs.lib // home-manager.lib;
-      systems = [ "x86_64-linux" "aarch64-linux" ];
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
       forEachSystem = f: lib.genAttrs systems (system: f pkgsFor.${system});
       pkgsFor = lib.genAttrs systems (system: import nixpkgs {
         inherit system;

--- a/flake.nix
+++ b/flake.nix
@@ -46,12 +46,13 @@
             ./nixos/hosts/bkp1.nwk2.rabbito.tech
           ];
         };
-        "lga-test1.tenant-29c7a3-baggie.coreweave.cloud" = lib.nixosSystem {
-          specialArgs = { inherit inputs outputs; };
-          modules = [
-            ./nixos/hosts/lga-test1.tenant-29c7a3-baggie.coreweave.cloud
-          ];
-        };
+        # FIXME: eval issue
+        # "lga-test1.tenant-29c7a3-baggie.coreweave.cloud" = lib.nixosSystem {
+        #   specialArgs = { inherit inputs outputs; };
+        #   modules = [
+        #     ./nixos/hosts/lga-test1.tenant-29c7a3-baggie.coreweave.cloud
+        #   ];
+        # };
         "e39.nwk3.rabbito.tech" = lib.nixosSystem {
           specialArgs = { inherit inputs outputs; };
           modules = [

--- a/pkgs/wayland-push-to-talk-fix/default.nix
+++ b/pkgs/wayland-push-to-talk-fix/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation {
     description = "This fixes the inability to use push to talk in Discord when running Wayland";
     homepage = "https://github.com/Rush/wayland-push-to-talk-fix";
     license = licenses.mit;
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
This PR configures the repo with GHA, a build matrix and Cachix.

For Cachix pushes to work, you'll have to create your own cache, set the
CACHIX_AUTH_TOKEN in the repo secrets and update the name of the cache from
"tmp-snowflake" (see the last commit).

Hope you enjoy the work, and let me know if you have any questions!

- **ci: add GitHub Actions matrix based on flake checks**
- **flake: disable broken lga-test1.tenant-29c7a3-baggie.coreweave.cloud**
- **flake: add all packages to checks**
- **flake: add nixos configurations to the checks**
- **flake: disable broken home config**
- **flake: add x86_64-darwin to the list of supported systems**
- **flake: add home configurations to the checks**
- **ci: fixup**
- **ci: fix build matrix attributes**
- **ci: make the build matrix more readable**
- **ci: only build packages on supported systems**
- **wayland-push-to-talk-fix: only compile on linux**
- **ci: disable fail-fast**
- **ci: make space for large NixOS closures**
- **ci: cache build results**
