### PR TITLE
fix: update lock to bump for SSH CVE

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -486,16 +486,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1720360677,
-        "narHash": "sha256-osMf65j10emMULeVfAOqlWua9eiokwUsdhhk02IvITo=",
+        "lastModified": 1720237917,
+        "narHash": "sha256-FH6J/92eUks3iRjyT/MXot4ASexq1FPdKeEpxlFxKDc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f573e8d789e7e707e59f0565d61ed22dceec0447",
+        "rev": "d689a1ac7dff4324503214206d68fad7670c38ba",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "f573e8d789e7e707e59f0565d61ed22dceec0447",
+        "ref": "d689a1ac7dff4324503214206d68fad7670c38ba",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -486,16 +486,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1720418205,
-        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
+        "lastModified": 1720360677,
+        "narHash": "sha256-osMf65j10emMULeVfAOqlWua9eiokwUsdhhk02IvITo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "655a58a72a6601292512670343087c2d75d859c1",
+        "rev": "f573e8d789e7e707e59f0565d61ed22dceec0447",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "f573e8d789e7e707e59f0565d61ed22dceec0447",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719677234,
-        "narHash": "sha256-qO9WZsj/0E6zcK4Ht1y/iJ8XfwbBzq7xdqhBh44OP/M=",
+        "lastModified": 1720470846,
+        "narHash": "sha256-7ftA4Bv5KfH4QdTRxqe8/Hz2YTKo+7IQ9n7vbNWgv28=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "36317d4d38887f7629876b0e43c8d9593c5cc48d",
+        "rev": "2fb5c1e0a17bc6059fa09dc411a43d75f35bb192",
         "type": "github"
       },
       "original": {
@@ -268,11 +268,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1719631702,
-        "narHash": "sha256-HMWxIehVO8pHp7OlqBYliiLOds34UJHSRn5FPdEb1j8=",
+        "lastModified": 1720432056,
+        "narHash": "sha256-rw8s4EsRSVtlAGNd5ttO4Ynb/eq0rMJsqG9zyREK3sk=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "2f9668e19aff06550cd154c87c0af120735a56a4",
+        "rev": "5d1928b925da7390eae3e369e6808d64cf916ed7",
         "type": "github"
       },
       "original": {
@@ -454,11 +454,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1719506693,
-        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
+        "lastModified": 1720418205,
+        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
+        "rev": "655a58a72a6601292512670343087c2d75d859c1",
         "type": "github"
       },
       "original": {
@@ -470,11 +470,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1718895438,
-        "narHash": "sha256-k3JqJrkdoYwE3fHE6xGDY676AYmyh4U2Zw+0Bwe5DLU=",
+        "lastModified": 1720031269,
+        "narHash": "sha256-rwz8NJZV+387rnWpTYcXaRNvzUSnnF9aHONoJIYmiUQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d603719ec6e294f034936c0d0dc06f689d91b6c3",
+        "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
         "type": "github"
       },
       "original": {
@@ -486,11 +486,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1719506693,
-        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
+        "lastModified": 1720418205,
+        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
+        "rev": "655a58a72a6601292512670343087c2d75d859c1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "anthr76 Flakes";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=d689a1ac7dff4324503214206d68fad7670c38ba";
+    nixpkgs.url = "github:nixos/nixpkgs";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "anthr76 Flakes";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=f573e8d789e7e707e59f0565d61ed22dceec0447";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=d689a1ac7dff4324503214206d68fad7670c38ba";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "anthr76 Flakes";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=f573e8d789e7e707e59f0565d61ed22dceec0447";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
```
• Updated input 'home-manager':
    'github:nix-community/home-manager/36317d4d38887f7629876b0e43c8d9593c5cc48d' (2024-06-29)
  → 'github:nix-community/home-manager/2fb5c1e0a17bc6059fa09dc411a43d75f35bb192' (2024-07-08)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b2852eb9365c6de48ffb0dc2c9562591f652242a' (2024-06-27)
  → 'github:nixos/nixpkgs/655a58a72a6601292512670343087c2d75d859c1' (2024-07-08)
• Updated input 'nixpkgs-unstable':
    'github:nixos/nixpkgs/b2852eb9365c6de48ffb0dc2c9562591f652242a' (2024-06-27)
  → 'github:nixos/nixpkgs/655a58a72a6601292512670343087c2d75d859c1' (2024-07-08)
• Updated input 'jovian-nixos':
    'github:Jovian-Experiments/Jovian-NixOS/2f9668e19aff06550cd154c87c0af120735a56a4' (2024-06-29)
  → 'github:Jovian-Experiments/Jovian-NixOS/5d1928b925da7390eae3e369e6808d64cf916ed7' (2024-07-08)
• Updated input 'jovian-nixos/nixpkgs':
    'github:NixOS/nixpkgs/d603719ec6e294f034936c0d0dc06f689d91b6c3' (2024-06-20)
  → 'github:NixOS/nixpkgs/9f4128e00b0ae8ec65918efeba59db998750ead6' (2024-07-03)
```